### PR TITLE
Small fixes for TaskTags

### DIFF
--- a/controllers/ChatMember/ChatMemberController.php
+++ b/controllers/ChatMember/ChatMemberController.php
@@ -15,6 +15,7 @@ use app\models\forms\ChatMember\UnpinChatMemberMessageForm;
 use app\models\search\ChatMemberMediaSearch;
 use app\models\search\ChatMemberSearch;
 use app\models\User;
+use app\models\views\ChatMemberSearchView;
 use app\repositories\ChatMemberRepository;
 use app\resources\CallResource;
 use app\resources\ChatMember\ChatMemberFullResource;
@@ -170,27 +171,31 @@ class ChatMemberController extends AppController
 
 	/**
 	 * @throws NotFoundHttpException
+	 * @throws ErrorException
 	 */
 	protected function findModel(int $id): ?ChatMember
 	{
 		// TODO: add in generator
 
-		$model = ChatMember::find()
-		                   ->byId($id)
+		$model = ChatMemberSearchView::find()
+		                             ->select([ChatMember::field('*'), 'last_call_rel_id' => 'last_call_rel.id'])
+		                             ->byId($id)
+		                             ->leftJoinLastCallRelation()
+		                             ->with(['lastCall.user.userProfile'])
 //		                   ->with(['messages' => function (ChatMemberMessageQuery $query) {
 //			                   $query->notDeleted();
 //		                   }])
-                           ->with(['objectChatMember.object.company'])
-		                   ->with([
-			                   'request.company',
-			                   'request.regions',
-			                   'request.directions',
-			                   'request.districts',
-			                   'request.objectTypes',
-			                   'request.objectClasses',
-		                   ])
-		                   ->with(['user.userProfile'])
-		                   ->one();
+                                     ->with(['objectChatMember.object.company'])
+		                             ->with([
+			                             'request.company',
+			                             'request.regions',
+			                             'request.directions',
+			                             'request.districts',
+			                             'request.objectTypes',
+			                             'request.objectClasses',
+		                             ])
+		                             ->with(['user.userProfile'])
+		                             ->one();
 
 		if ($model) {
 			return $model;

--- a/controllers/TaskTagController.php
+++ b/controllers/TaskTagController.php
@@ -13,7 +13,6 @@ use app\resources\Task\TaskTagResource;
 use app\usecases\TaskTag\TaskTagService;
 use Exception;
 use Throwable;
-use yii\data\ActiveDataProvider;
 use yii\db\StaleObjectException;
 use yii\web\NotFoundHttpException;
 
@@ -36,12 +35,12 @@ class TaskTagController extends AppController
 	/**
 	 * @throws ValidateException
 	 */
-	public function actionIndex(): ActiveDataProvider
+	public function actionIndex(): array
 	{
-		$searchModel  = new TaskTagSearch();
-		$dataProvider = $searchModel->search($this->request->get());
+		$searchModel = new TaskTagSearch();
+		$resource    = $searchModel->search($this->request->get())->all();
 
-		return TaskTagResource::fromDataProvider($dataProvider);
+		return TaskTagResource::collection($resource);
 	}
 
 	/**

--- a/controllers/TaskTagController.php
+++ b/controllers/TaskTagController.php
@@ -13,6 +13,7 @@ use app\resources\Task\TaskTagResource;
 use app\usecases\TaskTag\TaskTagService;
 use Exception;
 use Throwable;
+use yii\data\ActiveDataProvider;
 use yii\db\StaleObjectException;
 use yii\web\NotFoundHttpException;
 
@@ -35,12 +36,12 @@ class TaskTagController extends AppController
 	/**
 	 * @throws ValidateException
 	 */
-	public function actionIndex(): array
+	public function actionIndex(): ActiveDataProvider
 	{
-		$searchModel = new TaskTagSearch();
-		$resource    = $searchModel->search($this->request->get())->all();
+		$searchModel  = new TaskTagSearch();
+		$dataProvider = $searchModel->search($this->request->get());
 
-		return TaskTagResource::collection($resource);
+		return TaskTagResource::fromDataProvider($dataProvider);
 	}
 
 	/**

--- a/models/ChatMember.php
+++ b/models/ChatMember.php
@@ -173,6 +173,16 @@ class ChatMember extends AR
 		            ->via('relationFirst');
 	}
 
+	/**
+	 * @return ActiveQuery|TaskQuery
+	 * @throws ErrorException
+	 */
+	public function getLastCall(): ActiveQuery
+	{
+		return $this->morphHasOneVia(Call::class, 'id', 'second')
+		            ->via('relationFirst');
+	}
+
 	public static function find(): ChatMemberQuery
 	{
 		return new ChatMemberQuery(get_called_class());

--- a/models/ChatMember.php
+++ b/models/ChatMember.php
@@ -174,13 +174,24 @@ class ChatMember extends AR
 	}
 
 	/**
-	 * @return ActiveQuery|TaskQuery
+	 * @throws ErrorException
+	 */
+	public function getLastCallRelationFirst(): ActiveQuery
+	{
+		return $this->hasOne(Relation::class, [
+			'first_id'   => 'id',
+			'first_type' => 'morph',
+			'id'         => 'last_call_rel_id'
+		])->from([Relation::tableName() => Relation::getTable()]);
+	}
+
+	/**
 	 * @throws ErrorException
 	 */
 	public function getLastCall(): ActiveQuery
 	{
 		return $this->morphHasOneVia(Call::class, 'id', 'second')
-		            ->via('relationFirst');
+		            ->via('lastCallRelationFirst');
 	}
 
 	public static function find(): ChatMemberQuery

--- a/models/search/TaskTagSearch.php
+++ b/models/search/TaskTagSearch.php
@@ -4,8 +4,8 @@ namespace app\models\search;
 
 use app\kernel\common\models\exceptions\ValidateException;
 use app\kernel\common\models\Form\Form;
-use app\models\ActiveQuery\TaskTagQuery;
 use app\models\TaskTag;
+use yii\data\ActiveDataProvider;
 
 class TaskTagSearch extends Form
 {
@@ -30,12 +30,17 @@ class TaskTagSearch extends Form
 	/**
 	 * @param array $params
 	 *
-	 * @return TaskTagQuery
+	 * @return ActiveDataProvider
 	 * @throws ValidateException
 	 */
-	public function search(array $params): TaskTagQuery
+	public function search(array $params): ActiveDataProvider
 	{
 		$query = TaskTag::find()->notDeleted();
+
+		$dataProvider = new ActiveDataProvider([
+			'query'      => $query,
+			'pagination' => false
+		]);
 
 		$this->load($params);
 
@@ -63,6 +68,6 @@ class TaskTagSearch extends Form
 			]);
 		}
 
-		return $query;
+		return $dataProvider;
 	}
 }

--- a/models/search/TaskTagSearch.php
+++ b/models/search/TaskTagSearch.php
@@ -4,8 +4,8 @@ namespace app\models\search;
 
 use app\kernel\common\models\exceptions\ValidateException;
 use app\kernel\common\models\Form\Form;
+use app\models\ActiveQuery\TaskTagQuery;
 use app\models\TaskTag;
-use yii\data\ActiveDataProvider;
 
 class TaskTagSearch extends Form
 {
@@ -30,16 +30,12 @@ class TaskTagSearch extends Form
 	/**
 	 * @param array $params
 	 *
-	 * @return ActiveDataProvider
+	 * @return TaskTagQuery
 	 * @throws ValidateException
 	 */
-	public function search(array $params): ActiveDataProvider
+	public function search(array $params): TaskTagQuery
 	{
 		$query = TaskTag::find()->notDeleted();
-
-		$dataProvider = new ActiveDataProvider([
-			'query' => $query,
-		]);
 
 		$this->load($params);
 
@@ -67,6 +63,6 @@ class TaskTagSearch extends Form
 			]);
 		}
 
-		return $dataProvider;
+		return $query;
 	}
 }

--- a/resources/ChatMember/ChatMemberFullResource.php
+++ b/resources/ChatMember/ChatMemberFullResource.php
@@ -9,6 +9,7 @@ use app\models\ChatMember;
 use app\models\ObjectChatMember;
 use app\models\Request;
 use app\models\User;
+use app\resources\CallResource;
 use app\resources\Object\ObjectChatMemberResource;
 use app\resources\Request\RequestResource;
 use app\resources\User\UserResource;
@@ -32,7 +33,8 @@ class ChatMemberFullResource extends JsonResource
 			'created_at' => $this->resource->created_at,
 			'updated_at' => $this->resource->updated_at,
 			'model'      => $this->getModel()->toArray(),
-//			'messages'   => ChatMemberMessageResource::collection($this->resource->messages)
+			'last_call'  => CallResource::tryMakeArray($this->resource->lastCall),
+			//			'messages'   => ChatMemberMessageResource::collection($this->resource->messages)
 		];
 	}
 

--- a/usecases/TaskTag/TaskTagService.php
+++ b/usecases/TaskTag/TaskTagService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace app\usecases\TaskTag;
 
-use app\dto\TaskTag\CreateTaskObserverDto;
+use app\dto\TaskTag\TaskTagDto;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\TaskTag;
 use Throwable;
@@ -15,7 +15,7 @@ class TaskTagService
 	/**
 	 * @throws SaveModelException
 	 */
-	public function create(CreateTaskObserverDto $dto): TaskTag
+	public function create(TaskTagDto $dto): TaskTag
 	{
 		$model = new TaskTag([
 			'name'        => $dto->name,
@@ -31,7 +31,7 @@ class TaskTagService
 	/**
 	 * @throws SaveModelException
 	 */
-	public function update(TaskTag $model, CreateTaskObserverDto $dto): TaskTag
+	public function update(TaskTag $model, TaskTagDto $dto): TaskTag
 	{
 		$model->load([
 			'name'        => $dto->name,


### PR DESCRIPTION
1. Исправлено неправильное использование DTO (автозамена jetbrains спасибо)
2. TaskTagSearch теперь возвращает TaskTagQuery, вместо ADP. Тэгов для задач будет явно мало, возможно даже не больше 20. Поэтому не имеет смысла.
3. Добавил lastCall для ChatMemberFullResource