### PR TITLE
[#413] Manipulate user sessions

### DIFF
--- a/config/common/web/url_rules.php
+++ b/config/common/web/url_rules.php
@@ -7,13 +7,15 @@ return
 			'controller'    => 'user',
 			'except'        => [],
 			'extraPatterns' => [
-				'GET,OPTIONS'         => 'index',
-				'GET,OPTIONS <id>'    => 'view',
-				'POST,OPTIONS'        => 'create',
-				'PUT,OPTIONS <id>'    => 'update',
-				'DELETE,OPTIONS <id>' => 'delete',
-				'POST,OPTIONS login'  => 'login',
-				'POST,OPTIONS logout' => 'logout'
+				'GET,OPTIONS'                  => 'index',
+				'GET,OPTIONS <id>'             => 'view',
+				'POST,OPTIONS'                 => 'create',
+				'PUT,OPTIONS <id>'             => 'update',
+				'DELETE,OPTIONS <id>'          => 'delete',
+				'POST,OPTIONS login'           => 'login',
+				'POST,OPTIONS logout'          => 'logout',
+				'GET,OPTIONS <id>/sessions'    => 'sessions',
+				'DELETE,OPTIONS <id>/sessions' => 'delete-sessions',
 			],
 		],
 		[
@@ -385,6 +387,15 @@ return
 				'GET,OPTIONS'         => 'index',
 				'GET,OPTIONS <id>'    => 'view',
 				'PUT,OPTIONS <id>'    => 'update',
+				'DELETE,OPTIONS <id>' => 'delete',
+			],
+		],
+		[
+			'class'         => 'yii\rest\UrlRule',
+			'controller'    => 'session',
+			'except'        => [],
+			'extraPatterns' => [
+				'GET,OPTIONS'         => 'index',
 				'DELETE,OPTIONS <id>' => 'delete',
 			],
 		],

--- a/controllers/SessionController.php
+++ b/controllers/SessionController.php
@@ -35,9 +35,15 @@ class SessionController extends AppController
 	/**
 	 * @return ActiveDataProvider
 	 * @throws ValidateException
+	 * @throws ForbiddenHttpException
 	 */
 	public function actionIndex(): ActiveDataProvider
 	{
+		$identity = $this->user->identity;
+		if (!$identity->isAdministrator() && !$identity->isDirector()) {
+			throw new ForbiddenHttpException('У вас нет прав на просмотр сессий пользователей.');
+		}
+
 		$searchModel = new UserAccessTokenSearch();
 
 		$dataProvider = $searchModel->search($this->request->get());
@@ -59,7 +65,7 @@ class SessionController extends AppController
 		$user  = $this->user->identity;
 		$model = $this->findModel($id);
 
-		if ($model->user_id !== $user->id && !$user->isAdministrator()) {
+		if ($model->user_id !== $user->id && !$user->isAdministrator() && !$user->isDirector()) {
 			throw new ForbiddenHttpException('У вас нет прав на удаление сессии данного пользователя');
 		}
 

--- a/controllers/SessionController.php
+++ b/controllers/SessionController.php
@@ -40,7 +40,7 @@ class SessionController extends AppController
 	public function actionIndex(): ActiveDataProvider
 	{
 		$identity = $this->user->identity;
-		if (!$identity->isAdministrator() && !$identity->isDirector()) {
+		if (!$identity->isAdministrator() && !$identity->isOwner()) {
 			throw new ForbiddenHttpException('У вас нет прав на просмотр сессий пользователей.');
 		}
 
@@ -62,14 +62,14 @@ class SessionController extends AppController
 	 */
 	public function actionDelete(int $id): SuccessResponse
 	{
-		$user  = $this->user->identity;
-		$model = $this->findModel($id);
+		$identity = $this->user->identity;
+		$session  = $this->findModel($id);
 
-		if ($model->user_id !== $user->id && !$user->isAdministrator() && !$user->isDirector()) {
+		if ($session->user_id !== $identity->id && !$identity->isAdministrator() && !$identity->isOwner()) {
 			throw new ForbiddenHttpException('У вас нет прав на удаление сессии данного пользователя');
 		}
 
-		$this->accessTokenService->delete($model);
+		$this->accessTokenService->delete($session);
 
 		return new SuccessResponse('Сессия пользователя успешно удалена');
 	}

--- a/controllers/SessionController.php
+++ b/controllers/SessionController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace app\controllers;
+
+use app\kernel\common\controller\AppController;
+use app\kernel\common\models\exceptions\ModelNotFoundException;
+use app\kernel\common\models\exceptions\ValidateException;
+use app\kernel\web\http\responses\SuccessResponse;
+use app\models\search\UserAccessTokenSearch;
+use app\models\UserAccessToken;
+use app\resources\User\UserAccessTokenResource;
+use app\usecases\User\UserAccessTokenService;
+use Throwable;
+use yii\data\ActiveDataProvider;
+use yii\db\StaleObjectException;
+use yii\web\ForbiddenHttpException;
+
+class SessionController extends AppController
+{
+	private UserAccessTokenService $accessTokenService;
+
+
+	public function __construct(
+		$id,
+		$module,
+		UserAccessTokenService $accessTokenService,
+		array $config = []
+	)
+	{
+		$this->accessTokenService = $accessTokenService;
+
+		parent::__construct($id, $module, $config);
+	}
+
+	/**
+	 * @return ActiveDataProvider
+	 * @throws ValidateException
+	 */
+	public function actionIndex(): ActiveDataProvider
+	{
+		$searchModel = new UserAccessTokenSearch();
+
+		$dataProvider = $searchModel->search($this->request->get());
+
+		return UserAccessTokenResource::fromDataProvider($dataProvider);
+	}
+
+	/**
+	 * @param int $id
+	 *
+	 * @return SuccessResponse
+	 * @throws ForbiddenHttpException
+	 * @throws ModelNotFoundException
+	 * @throws Throwable
+	 * @throws StaleObjectException
+	 */
+	public function actionDelete(int $id): SuccessResponse
+	{
+		$user  = $this->user->identity;
+		$model = $this->findModel($id);
+
+		if ($model->user_id !== $user->id && !$user->isAdministrator()) {
+			throw new ForbiddenHttpException('У вас нет прав на удаление сессии данного пользователя');
+		}
+
+		$this->accessTokenService->delete($model);
+
+		return new SuccessResponse('Сессия пользователя успешно удалена');
+	}
+
+	/**
+	 * @param int $id
+	 *
+	 * @return UserAccessToken
+	 * @throws ModelNotFoundException
+	 */
+	protected function findModel(int $id): UserAccessToken
+	{
+		return UserAccessToken::find()->byId($id)->oneOrThrow();
+	}
+}

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -175,14 +175,14 @@ class UserController extends AppController
 	 */
 	public function actionDelete(int $id): SuccessResponse
 	{
-		$user = $this->user->identity;
+		$identity = $this->user->identity;
 
-		if (!$user->isAdministrator()) {
+		if (!$identity->isAdministrator() && !$identity->isOwner()) {
 			throw new ForbiddenHttpException('У вас нет прав на удаление пользователя');
 		}
 
-		$model = $this->findModel($id);
-		$this->userService->delete($model);
+		$user = $this->findModel($id);
+		$this->userService->delete($user);
 
 		return new SuccessResponse('Пользователь успешно удален');
 	}
@@ -241,15 +241,15 @@ class UserController extends AppController
 	 */
 	public function actionSessions($id): array
 	{
-		$model = $this->findModel($id);
-		$user  = $this->user->identity;
+		$user     = $this->findModel($id);
+		$identity = $this->user->identity;
 
 		// TODO: Заменить на RBAC
-		if ($user->id !== $model->id && !$user->isAdministrator() && !$user->isDirector()) {
+		if ($identity->id !== $user->id && !$identity->isAdministrator() && !$identity->isOwner()) {
 			throw new ForbiddenHttpException('У вас нет прав на просмотр активных сессий данного пользователя');
 		}
 
-		$sessions = $this->accessTokenRepository->findAllValidByUserId($model->id);
+		$sessions = $this->accessTokenRepository->findAllValidByUserId($user->id);
 
 		return UserAccessTokenResource::collection($sessions);
 	}
@@ -270,7 +270,7 @@ class UserController extends AppController
 		$identity = $this->user->identity;
 
 		// TODO: Заменить на RBAC
-		if ($identity->id !== $user->id && !$identity->isAdministrator() && !$identity->isDirector()) {
+		if ($identity->id !== $user->id && !$identity->isAdministrator() && !$identity->isOwner()) {
 			throw new ForbiddenHttpException('У вас нет прав на управление сессиями данного пользователя');
 		}
 

--- a/dto/Auth/AuthResultDto.php
+++ b/dto/Auth/AuthResultDto.php
@@ -11,4 +11,5 @@ class AuthResultDto extends BaseObject
 {
 	public User   $user;
 	public string $accessToken;
+	public int    $accessTokenId;
 }

--- a/dto/User/UserAccessTokenDto.php
+++ b/dto/User/UserAccessTokenDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\dto\User;
+
+use yii\base\BaseObject;
+
+class UserAccessTokenDto extends BaseObject
+{
+	public int    $user_id;
+	public string $access_token;
+	public string $expires_at;
+	public string $ip;
+	public string $user_agent;
+}

--- a/helpers/ArrayHelper.php
+++ b/helpers/ArrayHelper.php
@@ -65,4 +65,10 @@ class ArrayHelper
 	{
 		return self::isArray($array) ? $array : [$array];
 	}
+
+
+	public static function filter($array, callable $fn): array
+	{
+		return array_filter($array, $fn);
+	}
 }

--- a/helpers/StringHelper.php
+++ b/helpers/StringHelper.php
@@ -111,7 +111,7 @@ class StringHelper
 
 	public static function join(string $separator = ' ', string ...$strings): string
 	{
-		$notEmptyStrings = ArrayHelper::filter(ArrayHelper::toArray($strings), fn($str) => self::notEmpty($str));
+		$notEmptyStrings = ArrayHelper::filter($strings, fn($str) => self::notEmpty($str));
 
 		return join($separator, $notEmptyStrings);
 	}

--- a/helpers/StringHelper.php
+++ b/helpers/StringHelper.php
@@ -6,6 +6,8 @@ namespace app\helpers;
 
 class StringHelper
 {
+	public const SYMBOL_SPACE = ' ';
+
 	/**
 	 * Checks if a string is empty.
 	 *
@@ -91,7 +93,7 @@ class StringHelper
 	 *
 	 * @return string
 	 */
-	public static function toUpperCase(string $string): string
+	public static function ucFirst(string $string): string
 	{
 		return ucfirst($string);
 	}
@@ -105,5 +107,12 @@ class StringHelper
 	public static function trim(string $string, string $characters = " \t\n\r\0\x0B"): string
 	{
 		return trim($string, $characters);
+	}
+
+	public static function join(string $separator = ' ', string ...$strings): string
+	{
+		$notEmptyStrings = ArrayHelper::filter(ArrayHelper::toArray($strings), fn($str) => self::notEmpty($str));
+
+		return join($separator, $notEmptyStrings);
 	}
 }

--- a/helpers/StringHelper.php
+++ b/helpers/StringHelper.php
@@ -73,4 +73,37 @@ class StringHelper
 
 		return substr($string, $pos + strlen($after));
 	}
+
+	/**
+	 * Returns first symbol in string
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	public static function first(string $string): string
+	{
+		return mb_substr($string, 0, 1);
+	}
+
+	/**
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	public static function toUpperCase(string $string): string
+	{
+		return ucfirst($string);
+	}
+
+	/**
+	 * @param string $string
+	 * @param string $characters
+	 *
+	 * @return string
+	 */
+	public static function trim(string $string, string $characters = " \t\n\r\0\x0B"): string
+	{
+		return trim($string, $characters);
+	}
 }

--- a/models/ActiveQuery/UserAccessTokenQuery.php
+++ b/models/ActiveQuery/UserAccessTokenQuery.php
@@ -75,4 +75,14 @@ class UserAccessTokenQuery extends AQ
 	{
 		return $this->andWhere(['user_id' => $userId]);
 	}
+
+	/**
+	 * @param string $token
+	 *
+	 * @return UserAccessTokenQuery
+	 */
+	public function excludeToken(string $token): self
+	{
+		return $this->andWhere(['!=', 'access_token', $token]);
+	}
 }

--- a/models/User.php
+++ b/models/User.php
@@ -260,7 +260,7 @@ class User extends AR implements IdentityInterface, NotifiableInterface
 	/**
 	 * @return bool
 	 */
-	public function isDirector(): bool
+	public function isOwner(): bool
 	{
 		return $this->role === self::ROLE_OWNER;
 	}

--- a/models/User.php
+++ b/models/User.php
@@ -256,4 +256,12 @@ class User extends AR implements IdentityInterface, NotifiableInterface
 	{
 		return $this->role === self::ROLE_ADMIN;
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function isDirector(): bool
+	{
+		return $this->role === self::ROLE_OWNER;
+	}
 }

--- a/models/UserAccessToken.php
+++ b/models/UserAccessToken.php
@@ -26,7 +26,7 @@ class UserAccessToken extends AR
 	protected bool $useSoftDelete = true;
 	protected bool $useSoftUpdate = true;
 
-	const EXPIRES_IN_DAYS = 14;
+	const EXPIRES_IN_DAYS = 30;
 
 	/**
 	 * {@inheritdoc}

--- a/models/UserAccessToken.php
+++ b/models/UserAccessToken.php
@@ -16,6 +16,8 @@ use app\models\ActiveQuery\UserQuery;
  * @property string    $created_at
  * @property string    $updated_at
  * @property string    $deleted_at
+ * @property string    $user_agent
+ * @property string    $ip
  *
  * @property-read User $user
  */
@@ -43,8 +45,11 @@ class UserAccessToken extends AR
 			[['user_id', 'access_token'], 'required'],
 			[['user_id'], 'integer'],
 			[['access_token'], 'string', 'max' => 255],
+			[['user_agent'], 'string', 'max' => 1024],
+			[['ip'], 'string', 'max' => 15],
 			[['created_at', 'updated_at', 'expires_at'], 'safe'],
-			[['user_id'], 'exist', 'skipOnError' => true, 'targetClass' => User::className(), 'targetAttribute' => ['user_id' => 'id']]
+			[['user_id'], 'exist', 'skipOnError' => true, 'targetClass' => User::class, 'targetAttribute' => ['user_id' => 'id']],
+
 		];
 	}
 

--- a/models/search/UserAccessTokenSearch.php
+++ b/models/search/UserAccessTokenSearch.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace app\models\search;
+
+use app\kernel\common\models\exceptions\ValidateException;
+use app\kernel\common\models\Form\Form;
+use app\models\User;
+use app\models\UserAccessToken;
+use yii\data\ActiveDataProvider;
+
+class UserAccessTokenSearch extends Form
+{
+	public ?int   $id;
+	public ?array $user_ids;
+
+	public function rules(): array
+	{
+		return [
+			[['id'], 'integer'],
+			['user_ids', 'each', 'rule' => [
+				'exist',
+				'targetClass'     => User::class,
+				'targetAttribute' => ['user_ids' => 'id'],
+			]],
+		];
+	}
+
+	/**
+	 * @param array $params
+	 *
+	 * @return ActiveDataProvider
+	 * @throws ValidateException
+	 */
+	public function search(array $params): ActiveDataProvider
+	{
+		$query = UserAccessToken::find()->valid();
+
+		$dataProvider = new ActiveDataProvider([
+			'query' => $query,
+			'sort'  => [
+				'defaultOrder' => [
+					'created_at' => SORT_DESC,
+				],
+				'attributes'   => [
+					'created_at',
+					'expires_at',
+					'user_id'
+				]
+			]
+		]);
+
+		$this->load($params);
+
+		$this->validateOrThrow();
+
+		$query->andFilterWhere([
+			'id'      => $this->id,
+			'user_id' => $this->user_ids
+		]);
+
+		return $dataProvider;
+	}
+}

--- a/models/search/UserAccessTokenSearch.php
+++ b/models/search/UserAccessTokenSearch.php
@@ -10,8 +10,8 @@ use yii\data\ActiveDataProvider;
 
 class UserAccessTokenSearch extends Form
 {
-	public ?int   $id;
-	public ?array $user_ids;
+	public $id;
+	public $user_ids;
 
 	public function rules(): array
 	{

--- a/repositories/UserAccessTokenRepository.php
+++ b/repositories/UserAccessTokenRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\repositories;
+
+use app\models\UserAccessToken;
+
+class UserAccessTokenRepository
+{
+	/**
+	 * @param int $id
+	 *
+	 * @return UserAccessToken[]
+	 */
+	public function findAllValidByUserId(int $id): array
+	{
+		return UserAccessToken::find()->byUserId($id)->valid()->all();
+	}
+}

--- a/resources/Auth/AuthLoginResource.php
+++ b/resources/Auth/AuthLoginResource.php
@@ -22,8 +22,9 @@ class AuthLoginResource extends JsonResource
 		return [
 			'message' => 'Авторизация прошла успешно. Добро пожаловать!',
 			'data'    => [
-				'user'         => UserResource::tryMakeArray($this->resource->user),
-				'access_token' => $this->resource->accessToken,
+				'user'            => UserResource::tryMakeArray($this->resource->user),
+				'access_token'    => $this->resource->accessToken,
+				'access_token_id' => $this->resource->accessTokenId
 			]
 		];
 	}

--- a/resources/User/UserAccessTokenResource.php
+++ b/resources/User/UserAccessTokenResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\resources\User;
+
+use app\kernel\web\http\resources\JsonResource;
+use app\models\UserAccessToken;
+
+class UserAccessTokenResource extends JsonResource
+{
+	private UserAccessToken $resource;
+
+	public function __construct(UserAccessToken $resource)
+	{
+		$this->resource = $resource;
+	}
+
+	public function toArray(): array
+	{
+		return [
+			'id'         => $this->resource->id,
+			'expires_at' => $this->resource->expires_at,
+			'created_at' => $this->resource->created_at,
+			'deleted_at' => $this->resource->deleted_at,
+			'user_agent' => $this->resource->user_agent,
+			'ip'         => $this->resource->ip
+		];
+	}
+}

--- a/resources/User/UserProfileResource.php
+++ b/resources/User/UserProfileResource.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace app\resources\User;
 
 use app\kernel\web\http\resources\JsonResource;
-use app\models\User;
 use app\models\UserProfile;
 
 class UserProfileResource extends JsonResource
@@ -28,6 +27,17 @@ class UserProfileResource extends JsonResource
 			'medium_name' => $this->resource->getMediumName(),
 			'caller_id'   => $this->resource->caller_id,
 			'avatar'      => $this->resource->avatar,
+			'full_name'   => $this->getFullName()
 		];
+	}
+
+	public function getFullName(): string
+	{
+		$fullName = "{$this->resource->middle_name} {$this->resource->first_name}";
+		if ($this->resource->last_name) {
+			$fullName .= " {$this->resource->last_name}";
+		}
+
+		return $fullName;
 	}
 }

--- a/resources/User/UserProfileResource.php
+++ b/resources/User/UserProfileResource.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace app\resources\User;
 
-use app\helpers\StringHelper;
 use app\kernel\web\http\resources\JsonResource;
 use app\models\UserProfile;
 
@@ -27,38 +26,9 @@ class UserProfileResource extends JsonResource
 			'last_name'   => $this->resource->last_name,
 			'caller_id'   => $this->resource->caller_id,
 			'avatar'      => $this->resource->avatar,
-			'medium_name' => $this->getMediumName(),
-			'full_name'   => $this->getFullName(),
-			'short_name'  => $this->getShortName()
+			'medium_name' => $this->resource->getMediumName(),
+			'full_name'   => $this->resource->getFullName(),
+			'short_name'  => $this->resource->getShortName()
 		];
-	}
-
-	public function getFullName(): string
-	{
-		return StringHelper::join(
-			StringHelper::SYMBOL_SPACE,
-			$this->resource->middle_name ?? "",
-			$this->resource->first_name,
-			$this->resource->last_name ?? ""
-		);
-	}
-
-	public function getShortName(): string
-	{
-		$firstNameCharacter = StringHelper::ucFirst(StringHelper::first($this->resource->first_name));
-		$lastNameCharacter  = StringHelper::ucFirst(StringHelper::first($this->resource->last_name ?? ""));
-
-		$characters = StringHelper::join(". ", $firstNameCharacter, $lastNameCharacter);
-
-		return StringHelper::join(StringHelper::SYMBOL_SPACE, $this->resource->middle_name ?? "", $characters) . ".";
-	}
-
-	public function getMediumName(): string
-	{
-		return StringHelper::join(
-			StringHelper::SYMBOL_SPACE,
-			$this->resource->first_name,
-			$this->resource->middle_name ?? ""
-		);
 	}
 }

--- a/resources/User/UserProfileResource.php
+++ b/resources/User/UserProfileResource.php
@@ -35,30 +35,30 @@ class UserProfileResource extends JsonResource
 
 	public function getFullName(): string
 	{
-		$fullName = "{$this->resource->middle_name} {$this->resource->first_name}";
-		if ($this->resource->last_name) {
-			$fullName .= " {$this->resource->last_name}";
-		}
-
-		return $fullName;
+		return StringHelper::join(
+			StringHelper::SYMBOL_SPACE,
+			$this->resource->middle_name ?? "",
+			$this->resource->first_name,
+			$this->resource->last_name ?? ""
+		);
 	}
 
 	public function getShortName(): string
 	{
-		$firstName = StringHelper::toUpperCase(StringHelper::first($this->resource->first_name)) . '.';
-		$lastName  = "";
+		$firstNameCharacter = StringHelper::ucFirst(StringHelper::first($this->resource->first_name));
+		$lastNameCharacter  = StringHelper::ucFirst(StringHelper::first($this->resource->last_name ?? ""));
 
-		if ($this->resource->last_name) {
-			$lastName = StringHelper::toUpperCase(StringHelper::first($this->resource->last_name)) . '.';
-		}
+		$characters = StringHelper::join(". ", $firstNameCharacter, $lastNameCharacter);
 
-		$shortName = $this->resource->middle_name . " $firstName $lastName";
-
-		return StringHelper::trim($shortName);
+		return StringHelper::join(StringHelper::SYMBOL_SPACE, $this->resource->middle_name ?? "", $characters) . ".";
 	}
 
 	public function getMediumName(): string
 	{
-		return StringHelper::trim($this->resource->first_name . " " . $this->resource->middle_name);
+		return StringHelper::join(
+			StringHelper::SYMBOL_SPACE,
+			$this->resource->first_name,
+			$this->resource->middle_name ?? ""
+		);
 	}
 }

--- a/resources/User/UserProfileResource.php
+++ b/resources/User/UserProfileResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace app\resources\User;
 
+use app\helpers\StringHelper;
 use app\kernel\web\http\resources\JsonResource;
 use app\models\UserProfile;
 
@@ -24,10 +25,11 @@ class UserProfileResource extends JsonResource
 			'first_name'  => $this->resource->first_name,
 			'middle_name' => $this->resource->middle_name,
 			'last_name'   => $this->resource->last_name,
-			'medium_name' => $this->resource->getMediumName(),
 			'caller_id'   => $this->resource->caller_id,
 			'avatar'      => $this->resource->avatar,
-			'full_name'   => $this->getFullName()
+			'medium_name' => $this->getMediumName(),
+			'full_name'   => $this->getFullName(),
+			'short_name'  => $this->getShortName()
 		];
 	}
 
@@ -39,5 +41,24 @@ class UserProfileResource extends JsonResource
 		}
 
 		return $fullName;
+	}
+
+	public function getShortName(): string
+	{
+		$firstName = StringHelper::toUpperCase(StringHelper::first($this->resource->first_name)) . '.';
+		$lastName  = "";
+
+		if ($this->resource->last_name) {
+			$lastName = StringHelper::toUpperCase(StringHelper::first($this->resource->last_name)) . '.';
+		}
+
+		$shortName = $this->resource->middle_name . " $firstName $lastName";
+
+		return StringHelper::trim($shortName);
+	}
+
+	public function getMediumName(): string
+	{
+		return StringHelper::trim($this->resource->first_name . " " . $this->resource->middle_name);
 	}
 }

--- a/usecases/User/UserAccessTokenService.php
+++ b/usecases/User/UserAccessTokenService.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\usecases\User;
+
+use app\dto\User\UserAccessTokenDto;
+use app\kernel\common\database\interfaces\transaction\TransactionBeginnerInterface;
+use app\kernel\common\models\exceptions\SaveModelException;
+use app\models\UserAccessToken;
+use Throwable;
+use yii\db\StaleObjectException;
+
+class UserAccessTokenService
+{
+	private TransactionBeginnerInterface $transactionBeginner;
+
+	public function __construct(
+		TransactionBeginnerInterface $transactionBeginner
+	)
+	{
+		$this->transactionBeginner = $transactionBeginner;
+	}
+
+	/**
+	 * @param UserAccessTokenDto $dto
+	 *
+	 * @return UserAccessToken
+	 * @throws SaveModelException
+	 */
+	public function create(UserAccessTokenDto $dto): UserAccessToken
+	{
+		$model = new UserAccessToken([
+			'user_id'      => $dto->user_id,
+			'access_token' => $dto->access_token,
+			'expires_at'   => $dto->expires_at,
+			'ip'           => $dto->ip,
+			'user_agent'   => $dto->user_agent
+		]);
+
+		$model->saveOrThrow();
+
+		return $model;
+	}
+
+	/**
+	 * @param UserAccessToken $model
+	 *
+	 * @return void
+	 * @throws StaleObjectException
+	 * @throws Throwable
+	 */
+	public function delete(UserAccessToken $model): void
+	{
+		$model->delete();
+	}
+
+	/**
+	 * @throws Throwable
+	 * @throws StaleObjectException
+	 */
+	public function deleteAllByUserId(int $userId, array $excludeIds = [])
+	{
+		$tx = $this->transactionBeginner->begin();
+
+		try {
+			$models = UserAccessToken::find()->valid()->byUserId($userId)->andWhere(['not in', 'id', $excludeIds])->all();
+
+			foreach ($models as $model) {
+				$this->delete($model);
+			}
+
+			$tx->commit();
+		} catch (Throwable $th) {
+			$tx->rollBack();
+			throw $th;
+		}
+	}
+
+}


### PR DESCRIPTION
1. Добавлены урлы для работы с сессиями. У `/users` это `GET` `/users/:id/sessions` для списка всех сессий юзера и `DELETE` `/users/:id/sessions` для удаления всех сессий юзера. Отдельно создан эндпоинт `/sessions` для просмотра всех сессий всех пользователей и удаления конкретной сессии по `id`.
2. Создан `userAccessTokenService` для инкапсуляции логики работы с этой моделью.
3. Количество дней жизни токена увеличено до 30 (было 14).
4. При логине на клиент возвращается еще и `id` текущего токена (нужно для определения на странице "Безопасность", какой именно токен является текущим).
5. Если запрос на удаление всех токенов сотрудника прилетел от самого сотрудника, то удалятся все сессии кроме текущей. Если запрос прилетел от администратора, то удалятся абсолютно все активные токены юзера. (Логика проверки будет потом изменена с использованием RBAC)