### PR TITLE
Hotfix: fix Objects url

### DIFF
--- a/config/common/web/url_rules.php
+++ b/config/common/web/url_rules.php
@@ -112,6 +112,7 @@ return
 			'controller'    => 'oldDb/object',
 			'except'        => [],
 			'extraPatterns' => [
+				'GET,OPTIONS'                               => 'index',
 				'GET,OPTIONS offers'                        => 'offers',
 				'GET,OPTIONS offers-map'                    => 'offers-map',
 				'GET,OPTIONS offers-count'                  => 'offers-count',
@@ -158,13 +159,6 @@ return
 			'controller'    => ['company-events-log' => 'company-events-log'],
 			'except'        => [],
 			'extraPatterns' => [],
-		],
-		[
-			'class'         => 'yii\rest\UrlRule',
-			'controller'    => ['objects' => 'objects'],
-			'extraPatterns' => [
-				'GET,OPTIONS' => 'index'
-			],
 		],
 		[
 			'class'         => 'yii\rest\UrlRule',


### PR DESCRIPTION
Исправлен урл у `olddb//objects/`
На фронт из-за этого прилетали корсы
Как я понял, второй эндпоинт (который я щас удалил) обрабатывался новым контролером (на AppController) только лишь с одним методом `index`. Но уже не имеет смысла, так как я старый перевел на него.