### PR TITLE
Survey relation for Task

### DIFF
--- a/builders/Task/TaskBuilder.php
+++ b/builders/Task/TaskBuilder.php
@@ -19,13 +19,14 @@ class TaskBuilder
 	protected bool $assignedToCreatedBy = false;
 	protected int  $status              = Task::STATUS_CREATED;
 
-	protected ?User              $user        = null;
-	protected                    $createdBy   = null;
-	protected ?string            $message     = null;
+	protected ?User              $user                   = null;
+	protected                    $createdBy              = null;
+	protected ?string            $message                = null;
 	protected DateTimeInterface  $start;
-	protected ?DateTimeInterface $end         = null;
-	protected array              $tagIds      = [];
-	protected array              $observerIds = [];
+	protected ?DateTimeInterface $end                    = null;
+	protected array              $tagIds                 = [];
+	protected array              $observerIds            = [];
+	protected ?int               $surveyQuestionAnswerId = null;
 
 	protected UserRepository $userRepository;
 
@@ -190,6 +191,18 @@ class TaskBuilder
 		return $this;
 	}
 
+	public function setSurveyQuestionAnswerId(int $surveyQuestionAnswerId): self
+	{
+		$this->surveyQuestionAnswerId = $surveyQuestionAnswerId;
+
+		return $this;
+	}
+
+	public function getSurveyQuestionAnswerId(): ?int
+	{
+		return $this->surveyQuestionAnswerId;
+	}
+
 	public function validateOrThrow(): void
 	{
 		if (is_null($this->duration) && is_null($this->end)) {
@@ -218,15 +231,16 @@ class TaskBuilder
 		$this->validateOrThrow();
 
 		return new CreateTaskDto([
-			'user'            => $this->getUser(),
-			'message'         => $this->message,
-			'status'          => $this->getStatus(),
-			'start'           => $this->getStart(),
-			'end'             => $this->getEnd(),
-			'created_by_id'   => $this->getCreatedById(),
-			'created_by_type' => $this->getCreatedByType(),
-			'tagIds'          => $this->tagIds,
-			'observerIds'     => $this->observerIds,
+			'user'                   => $this->getUser(),
+			'message'                => $this->message,
+			'status'                 => $this->getStatus(),
+			'start'                  => $this->getStart(),
+			'end'                    => $this->getEnd(),
+			'created_by_id'          => $this->getCreatedById(),
+			'created_by_type'        => $this->getCreatedByType(),
+			'tagIds'                 => $this->tagIds,
+			'observerIds'            => $this->observerIds,
+			'surveyQuestionAnswerId' => $this->getSurveyQuestionAnswerId()
 		]);
 	}
 }

--- a/components/EffectStrategy/Service/CreateEffectSystemMessageService.php
+++ b/components/EffectStrategy/Service/CreateEffectSystemMessageService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\components\EffectStrategy\Service;
+
+use app\dto\ChatMember\CreateChatMemberSystemMessageDto;
+use app\kernel\common\models\exceptions\SaveModelException;
+use app\models\ChatMember;
+use app\models\ChatMemberMessage;
+use app\models\Survey;
+use app\usecases\ChatMember\ChatMemberMessageService;
+
+class CreateEffectSystemMessageService
+{
+	private ChatMemberMessageService $chatMemberMessageService;
+
+	public function __construct(ChatMemberMessageService $chatMemberMessageService)
+	{
+		$this->chatMemberMessageService = $chatMemberMessageService;
+	}
+
+	/**
+	 * @throws SaveModelException
+	 * @throws \Throwable
+	 */
+	public function createSystemMessage(ChatMember $chatMember, Survey $survey, string $message): ChatMemberMessage
+	{
+		$dto = new CreateChatMemberSystemMessageDto([
+			'message'    => $message,
+			'to'         => $chatMember,
+			'surveyIds'  => [$survey->id],
+			'contactIds' => [$survey->contact_id],
+		]);
+
+		return $this->chatMemberMessageService->createSystemMessage($dto);
+	}
+}

--- a/components/EffectStrategy/Service/CreateEffectTaskService.php
+++ b/components/EffectStrategy/Service/CreateEffectTaskService.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\components\EffectStrategy\Service;
+
+use app\builders\Task\TaskBuilderFactory;
+use app\kernel\common\models\exceptions\SaveModelException;
+use app\models\ChatMemberMessage;
+use app\models\SurveyQuestionAnswer;
+use app\models\Task;
+use app\models\User;
+use app\usecases\ChatMember\ChatMemberMessageService;
+use Throwable;
+
+class CreateEffectTaskService
+{
+	private TaskBuilderFactory       $taskBuilderFactory;
+	private ChatMemberMessageService $chatMemberMessageService;
+
+	public function __construct(TaskBuilderFactory $taskBuilderFactory, ChatMemberMessageService $chatMemberMessageService)
+	{
+		$this->taskBuilderFactory       = $taskBuilderFactory;
+		$this->chatMemberMessageService = $chatMemberMessageService;
+	}
+
+	/**
+	 * @throws SaveModelException
+	 * @throws Throwable
+	 */
+	public function createTaskForMessage(ChatMemberMessage $message, User $user, SurveyQuestionAnswer $surveyQuestionAnswer, string $text): Task
+	{
+		$dto = $this->taskBuilderFactory
+			->createEffectBuilder()
+			->setMessage($text)
+			->setCreatedBy($user)
+			->setSurveyQuestionAnswerId($surveyQuestionAnswer->id)
+			->build();
+
+		return $this->chatMemberMessageService->createTask($message, $dto);
+	}
+}

--- a/components/EffectStrategy/Strategies/CompanyHasNewRequestEffectStrategy.php
+++ b/components/EffectStrategy/Strategies/CompanyHasNewRequestEffectStrategy.php
@@ -2,11 +2,10 @@
 
 namespace app\components\EffectStrategy\Strategies;
 
-use app\builders\Task\TaskBuilderFactory;
 use app\components\EffectStrategy\AbstractEffectStrategy;
-use app\dto\ChatMember\CreateChatMemberSystemMessageDto;
+use app\components\EffectStrategy\Service\CreateEffectSystemMessageService;
+use app\components\EffectStrategy\Service\CreateEffectTaskService;
 use app\kernel\common\database\interfaces\transaction\TransactionBeginnerInterface;
-use app\kernel\common\models\exceptions\ModelNotFoundException;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\ChatMember;
 use app\models\ChatMemberMessage;
@@ -14,29 +13,26 @@ use app\models\Company;
 use app\models\QuestionAnswer;
 use app\models\Survey;
 use app\models\SurveyQuestionAnswer;
-use app\models\User;
 use app\services\ChatMemberSystemMessage\CompanyHasNewRequestSystemMessage;
-use app\usecases\ChatMember\ChatMemberMessageService;
 use Throwable;
-use yii\base\Exception;
 
 class CompanyHasNewRequestEffectStrategy extends AbstractEffectStrategy
 {
 	private const TASK_MESSAGE_TEXT = 'Новый запрос у %s (#%s), нужно оформить его.';
 
-	protected ChatMemberMessageService     $chatMemberMessageService;
-	protected TransactionBeginnerInterface $transactionBeginner;
-	protected TaskBuilderFactory           $taskBuilderFactory;
+	private TransactionBeginnerInterface     $transactionBeginner;
+	private CreateEffectTaskService          $effectTaskService;
+	private CreateEffectSystemMessageService $effectSystemMessageService;
 
 	public function __construct(
-		ChatMemberMessageService $chatMemberMessageService,
 		TransactionBeginnerInterface $transactionBeginner,
-		TaskBuilderFactory $taskBuilderFactory
+		CreateEffectTaskService $effectTaskService,
+		CreateEffectSystemMessageService $effectSystemMessageService
 	)
 	{
-		$this->chatMemberMessageService = $chatMemberMessageService;
-		$this->transactionBeginner      = $transactionBeginner;
-		$this->taskBuilderFactory       = $taskBuilderFactory;
+		$this->transactionBeginner        = $transactionBeginner;
+		$this->effectTaskService          = $effectTaskService;
+		$this->effectSystemMessageService = $effectSystemMessageService;
 	}
 
 	public function shouldBeProcessed(Survey $survey, QuestionAnswer $answer): bool
@@ -63,7 +59,7 @@ class CompanyHasNewRequestEffectStrategy extends AbstractEffectStrategy
 				$this->sendSystemMessageIntoCompany($chatMember, $survey);
 			}
 
-			$this->createTaskForMessage($surveyChatMemberMessage, $survey->user, $chatMemberModel);
+			$this->effectTaskService->createTaskForMessage($surveyChatMemberMessage, $survey->user, $surveyQuestionAnswer, $this->getTaskMessage($chatMemberModel));
 
 			$tx->commit();
 		} catch (Throwable $th) {
@@ -82,35 +78,11 @@ class CompanyHasNewRequestEffectStrategy extends AbstractEffectStrategy
 		                                            ->setSurveyId($survey->id)
 		                                            ->toMessage();
 
-		$dto = new CreateChatMemberSystemMessageDto([
-			'message'    => $message,
-			'to'         => $chatMember,
-			'surveyIds'  => [$survey->id],
-			'contactIds' => [$survey->contact_id],
-		]);
-
-		$this->chatMemberMessageService->createSystemMessage($dto);
+		$this->effectSystemMessageService->createSystemMessage($chatMember, $survey, $message);
 	}
 
 	protected function getTaskMessage(Company $company): string
 	{
 		return sprintf(self::TASK_MESSAGE_TEXT, $company->getFullName(), $company->id);
-	}
-
-	/**
-	 * @throws SaveModelException
-	 * @throws Throwable
-	 * @throws ModelNotFoundException
-	 * @throws Exception
-	 */
-	protected function createTaskForMessage(ChatMemberMessage $message, User $user, Company $company): void
-	{
-		$dto = $this->taskBuilderFactory
-			->createEffectBuilder()
-			->setMessage($this->getTaskMessage($company))
-			->setCreatedBy($user)
-			->build();
-
-		$this->chatMemberMessageService->createTask($message, $dto);
 	}
 }

--- a/components/EffectStrategy/Strategies/CompanyHasSubleaseOrStorageEffectStrategy.php
+++ b/components/EffectStrategy/Strategies/CompanyHasSubleaseOrStorageEffectStrategy.php
@@ -2,11 +2,10 @@
 
 namespace app\components\EffectStrategy\Strategies;
 
-use app\builders\Task\TaskBuilderFactory;
 use app\components\EffectStrategy\AbstractEffectStrategy;
-use app\dto\ChatMember\CreateChatMemberSystemMessageDto;
+use app\components\EffectStrategy\Service\CreateEffectSystemMessageService;
+use app\components\EffectStrategy\Service\CreateEffectTaskService;
 use app\kernel\common\database\interfaces\transaction\TransactionBeginnerInterface;
-use app\kernel\common\models\exceptions\ModelNotFoundException;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\ChatMember;
 use app\models\ChatMemberMessage;
@@ -14,29 +13,26 @@ use app\models\Company;
 use app\models\QuestionAnswer;
 use app\models\Survey;
 use app\models\SurveyQuestionAnswer;
-use app\models\User;
 use app\services\ChatMemberSystemMessage\CompanyHasSubleaseOrStorageSystemMessage;
-use app\usecases\ChatMember\ChatMemberMessageService;
 use Throwable;
-use yii\base\Exception;
 
 class CompanyHasSubleaseOrStorageEffectStrategy extends AbstractEffectStrategy
 {
 	private const TASK_MESSAGE_TEXT = '%s (#%s) - есть субаренда/ответ.хранение на складах, проанализировать в опроснике.';
 
-	protected ChatMemberMessageService     $chatMemberMessageService;
-	protected TransactionBeginnerInterface $transactionBeginner;
-	protected TaskBuilderFactory           $taskBuilderFactory;
+	private TransactionBeginnerInterface     $transactionBeginner;
+	private CreateEffectTaskService          $effectTaskService;
+	private CreateEffectSystemMessageService $effectSystemMessageService;
 
 	public function __construct(
-		ChatMemberMessageService $chatMemberMessageService,
 		TransactionBeginnerInterface $transactionBeginner,
-		TaskBuilderFactory $taskBuilderFactory
+		CreateEffectTaskService $effectTaskService,
+		CreateEffectSystemMessageService $effectSystemMessageService
 	)
 	{
-		$this->chatMemberMessageService = $chatMemberMessageService;
-		$this->transactionBeginner      = $transactionBeginner;
-		$this->taskBuilderFactory       = $taskBuilderFactory;
+		$this->transactionBeginner        = $transactionBeginner;
+		$this->effectTaskService          = $effectTaskService;
+		$this->effectSystemMessageService = $effectSystemMessageService;
 	}
 
 	public function shouldBeProcessed(Survey $survey, QuestionAnswer $answer): bool
@@ -63,7 +59,12 @@ class CompanyHasSubleaseOrStorageEffectStrategy extends AbstractEffectStrategy
 				$this->sendSystemMessageIntoCompany($chatMember, $survey);
 			}
 
-			$this->createTaskForMessage($surveyChatMemberMessage, $survey->user, $chatMemberModel);
+			$this->effectTaskService->createTaskForMessage(
+				$surveyChatMemberMessage,
+				$survey->user,
+				$surveyQuestionAnswer,
+				$this->getTaskMessage($chatMemberModel)
+			);
 
 			$tx->commit();
 		} catch (Throwable $th) {
@@ -82,35 +83,11 @@ class CompanyHasSubleaseOrStorageEffectStrategy extends AbstractEffectStrategy
 		                                                   ->setSurveyId($survey->id)
 		                                                   ->toMessage();
 
-		$dto = new CreateChatMemberSystemMessageDto([
-			'message'    => $message,
-			'to'         => $chatMember,
-			'surveyIds'  => [$survey->id],
-			'contactIds' => [$survey->contact_id],
-		]);
-
-		$this->chatMemberMessageService->createSystemMessage($dto);
+		$this->effectSystemMessageService->createSystemMessage($chatMember, $survey, $message);
 	}
 
 	protected function getTaskMessage(Company $company): string
 	{
 		return sprintf(self::TASK_MESSAGE_TEXT, $company->getFullName(), $company->id);
-	}
-
-	/**
-	 * @throws SaveModelException
-	 * @throws Throwable
-	 * @throws ModelNotFoundException
-	 * @throws Exception
-	 */
-	protected function createTaskForMessage(ChatMemberMessage $message, User $user, Company $company): void
-	{
-		$dto = $this->taskBuilderFactory
-			->createEffectBuilder()
-			->setMessage($this->getTaskMessage($company))
-			->setCreatedBy($user)
-			->build();
-
-		$this->chatMemberMessageService->createTask($message, $dto);
 	}
 }

--- a/components/EffectStrategy/Strategies/CompanyPlannedDevelopEffectStrategy.php
+++ b/components/EffectStrategy/Strategies/CompanyPlannedDevelopEffectStrategy.php
@@ -3,7 +3,7 @@
 namespace app\components\EffectStrategy\Strategies;
 
 use app\components\EffectStrategy\AbstractEffectStrategy;
-use app\dto\ChatMember\CreateChatMemberSystemMessageDto;
+use app\components\EffectStrategy\Service\CreateEffectSystemMessageService;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\ChatMember;
 use app\models\ChatMemberMessage;
@@ -13,18 +13,17 @@ use app\models\QuestionAnswer;
 use app\models\Survey;
 use app\models\SurveyQuestionAnswer;
 use app\services\ChatMemberSystemMessage\CompanyPlannedDevelopChatMemberSystemMessage;
-use app\usecases\ChatMember\ChatMemberMessageService;
 use Throwable;
 
 class CompanyPlannedDevelopEffectStrategy extends AbstractEffectStrategy
 {
-	private ChatMemberMessageService $chatMemberMessageService;
+	private CreateEffectSystemMessageService $effectSystemMessageService;
 
 	public function __construct(
-		ChatMemberMessageService $chatMemberMessageService
+		CreateEffectSystemMessageService $effectSystemMessageService
 	)
 	{
-		$this->chatMemberMessageService = $chatMemberMessageService;
+		$this->effectSystemMessageService = $effectSystemMessageService;
 	}
 
 	public function shouldBeProcessed(Survey $survey, QuestionAnswer $answer): bool
@@ -56,13 +55,6 @@ class CompanyPlannedDevelopEffectStrategy extends AbstractEffectStrategy
 		                                                       ->setSurveyId($survey->id)
 		                                                       ->toMessage();
 
-		$dto = new CreateChatMemberSystemMessageDto([
-			'message'    => $message,
-			'to'         => $chatMember,
-			'surveyIds'  => [$survey->id],
-			'contactIds' => [$survey->contact_id],
-		]);
-
-		$this->chatMemberMessageService->createSystemMessage($dto);
+		$this->effectSystemMessageService->createSystemMessage($chatMember, $survey, $message);
 	}
 }

--- a/components/EffectStrategy/Strategies/CompanyWantsToBuyOrBuildEffectStrategy.php
+++ b/components/EffectStrategy/Strategies/CompanyWantsToBuyOrBuildEffectStrategy.php
@@ -2,11 +2,10 @@
 
 namespace app\components\EffectStrategy\Strategies;
 
-use app\builders\Task\TaskBuilderFactory;
 use app\components\EffectStrategy\AbstractEffectStrategy;
-use app\dto\ChatMember\CreateChatMemberSystemMessageDto;
+use app\components\EffectStrategy\Service\CreateEffectSystemMessageService;
+use app\components\EffectStrategy\Service\CreateEffectTaskService;
 use app\kernel\common\database\interfaces\transaction\TransactionBeginnerInterface;
-use app\kernel\common\models\exceptions\ModelNotFoundException;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\ChatMember;
 use app\models\ChatMemberMessage;
@@ -15,29 +14,26 @@ use app\models\ObjectChatMember;
 use app\models\QuestionAnswer;
 use app\models\Survey;
 use app\models\SurveyQuestionAnswer;
-use app\models\User;
 use app\services\ChatMemberSystemMessage\CompanyWantsToBuyOrBuildSystemMessage;
-use app\usecases\ChatMember\ChatMemberMessageService;
 use Throwable;
-use yii\base\Exception;
 
 class CompanyWantsToBuyOrBuildEffectStrategy extends AbstractEffectStrategy
 {
 	private const TASK_MESSAGE_TEXT = '%s (#%s) - хотят купить или построить объект, нужно предложить им.';
 
-	private ChatMemberMessageService     $chatMemberMessageService;
-	private TaskBuilderFactory           $taskBuilderFactory;
-	private TransactionBeginnerInterface $transactionBeginner;
+	private TransactionBeginnerInterface     $transactionBeginner;
+	private CreateEffectTaskService          $effectTaskService;
+	private CreateEffectSystemMessageService $effectSystemMessageService;
 
 	public function __construct(
-		ChatMemberMessageService $chatMemberMessageService,
-		TaskBuilderFactory $taskBuilderFactory,
-		TransactionBeginnerInterface $transactionBeginner
+		TransactionBeginnerInterface $transactionBeginner,
+		CreateEffectTaskService $effectTaskService,
+		CreateEffectSystemMessageService $effectSystemMessageService
 	)
 	{
-		$this->chatMemberMessageService = $chatMemberMessageService;
-		$this->taskBuilderFactory       = $taskBuilderFactory;
-		$this->transactionBeginner      = $transactionBeginner;
+		$this->transactionBeginner        = $transactionBeginner;
+		$this->effectTaskService          = $effectTaskService;
+		$this->effectSystemMessageService = $effectSystemMessageService;
 	}
 
 	public function shouldBeProcessed(Survey $survey, QuestionAnswer $answer): bool
@@ -64,7 +60,7 @@ class CompanyWantsToBuyOrBuildEffectStrategy extends AbstractEffectStrategy
 				$this->sendSystemMessageIntoCompany($companyChatMember, $survey);
 			}
 
-			$this->createTaskForMessage($surveyChatMemberMessage, $survey->user, $chatMemberModel);
+			$this->effectTaskService->createTaskForMessage($surveyChatMemberMessage, $survey->user, $surveyQuestionAnswer, $this->getTaskMessage($chatMemberModel));
 
 			$tx->commit();
 		} catch (Throwable $th) {
@@ -83,35 +79,11 @@ class CompanyWantsToBuyOrBuildEffectStrategy extends AbstractEffectStrategy
 		                                                ->setSurveyId($survey->id)
 		                                                ->toMessage();
 
-		$dto = new CreateChatMemberSystemMessageDto([
-			'message'    => $message,
-			'to'         => $chatMember,
-			'surveyIds'  => [$survey->id],
-			'contactIds' => [$survey->contact_id],
-		]);
-
-		$this->chatMemberMessageService->createSystemMessage($dto);
+		$this->effectSystemMessageService->createSystemMessage($chatMember, $survey, $message);
 	}
 
 	public function getTaskMessage(Company $company): string
 	{
 		return sprintf(self::TASK_MESSAGE_TEXT, $company->getFullName(), $company->id);
-	}
-
-	/**
-	 * @throws ModelNotFoundException
-	 * @throws SaveModelException
-	 * @throws Throwable
-	 * @throws Exception
-	 */
-	protected function createTaskForMessage(ChatMemberMessage $message, User $user, Company $company): void
-	{
-		$dto = $this->taskBuilderFactory
-			->createEffectBuilder()
-			->setMessage($this->getTaskMessage($company))
-			->setCreatedBy($user)
-			->build();
-
-		$this->chatMemberMessageService->createTask($message, $dto);
 	}
 }

--- a/components/EffectStrategy/Strategies/ObjectHasEquipmentForSaleEffectStrategy.php
+++ b/components/EffectStrategy/Strategies/ObjectHasEquipmentForSaleEffectStrategy.php
@@ -2,34 +2,25 @@
 
 namespace app\components\EffectStrategy\Strategies;
 
-use app\builders\Task\TaskBuilderFactory;
 use app\components\EffectStrategy\AbstractEffectStrategy;
-use app\kernel\common\models\exceptions\ModelNotFoundException;
+use app\components\EffectStrategy\Service\CreateEffectTaskService;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\ChatMemberMessage;
 use app\models\ObjectChatMember;
 use app\models\QuestionAnswer;
 use app\models\Survey;
 use app\models\SurveyQuestionAnswer;
-use app\models\User;
-use app\usecases\ChatMember\ChatMemberMessageService;
 use Throwable;
-use yii\base\Exception;
 
 class ObjectHasEquipmentForSaleEffectStrategy extends AbstractEffectStrategy
 {
 	private const TASK_MESSAGE_TEXT = 'Объект %s - есть оборудование под продажу, нужно обработать.';
 
-	private ChatMemberMessageService $chatMemberMessageService;
-	private TaskBuilderFactory       $taskBuilderFactory;
+	private CreateEffectTaskService $effectTaskService;
 
-	public function __construct(
-		ChatMemberMessageService $chatMemberMessageService,
-		TaskBuilderFactory $taskBuilderFactory
-	)
+	public function __construct(CreateEffectTaskService $effectTaskService)
 	{
-		$this->chatMemberMessageService = $chatMemberMessageService;
-		$this->taskBuilderFactory       = $taskBuilderFactory;
+		$this->effectTaskService = $effectTaskService;
 	}
 
 	public function shouldBeProcessed(Survey $survey, QuestionAnswer $answer): bool
@@ -44,29 +35,17 @@ class ObjectHasEquipmentForSaleEffectStrategy extends AbstractEffectStrategy
 	public function process(Survey $survey, SurveyQuestionAnswer $surveyQuestionAnswer, ChatMemberMessage $surveyChatMemberMessage): void
 	{
 		$chatMemberModel = $survey->chatMember->model;
-		
-		$this->createTaskForMessage($surveyChatMemberMessage, $survey->user, $chatMemberModel);
+
+		$this->effectTaskService->createTaskForMessage(
+			$surveyChatMemberMessage,
+			$survey->user,
+			$surveyQuestionAnswer,
+			$this->getTaskMessage($chatMemberModel)
+		);
 	}
 
 	public function getTaskMessage(ObjectChatMember $objectChatMember): string
 	{
 		return sprintf(self::TASK_MESSAGE_TEXT, $objectChatMember->object_id);
-	}
-
-	/**
-	 * @throws ModelNotFoundException
-	 * @throws SaveModelException
-	 * @throws Throwable
-	 * @throws Exception
-	 */
-	protected function createTaskForMessage(ChatMemberMessage $message, User $user, ObjectChatMember $objectChatMember): void
-	{
-		$dto = $this->taskBuilderFactory
-			->createEffectBuilder()
-			->setMessage($this->getTaskMessage($objectChatMember))
-			->setCreatedBy($user)
-			->build();
-
-		$this->chatMemberMessageService->createTask($message, $dto);
 	}
 }

--- a/components/EffectStrategy/Strategies/ObjectHasFreeAreaEffectStrategy.php
+++ b/components/EffectStrategy/Strategies/ObjectHasFreeAreaEffectStrategy.php
@@ -2,34 +2,25 @@
 
 namespace app\components\EffectStrategy\Strategies;
 
-use app\builders\Task\TaskBuilderFactory;
 use app\components\EffectStrategy\AbstractEffectStrategy;
-use app\kernel\common\models\exceptions\ModelNotFoundException;
+use app\components\EffectStrategy\Service\CreateEffectTaskService;
 use app\kernel\common\models\exceptions\SaveModelException;
 use app\models\ChatMemberMessage;
 use app\models\ObjectChatMember;
 use app\models\QuestionAnswer;
 use app\models\Survey;
 use app\models\SurveyQuestionAnswer;
-use app\models\User;
-use app\usecases\ChatMember\ChatMemberMessageService;
 use Throwable;
-use yii\base\Exception;
 
 class ObjectHasFreeAreaEffectStrategy extends AbstractEffectStrategy
 {
 	private const TASK_MESSAGE_TEXT = 'Объект %s - есть свободная площадь в аренду, нужно обработать.';
 
-	private ChatMemberMessageService $chatMemberMessageService;
-	private TaskBuilderFactory       $taskBuilderFactory;
+	private CreateEffectTaskService $effectTaskService;
 
-	public function __construct(
-		ChatMemberMessageService $chatMemberMessageService,
-		TaskBuilderFactory $taskBuilderFactory
-	)
+	public function __construct(CreateEffectTaskService $effectTaskService)
 	{
-		$this->chatMemberMessageService = $chatMemberMessageService;
-		$this->taskBuilderFactory       = $taskBuilderFactory;
+		$this->effectTaskService = $effectTaskService;
 	}
 
 	public function shouldBeProcessed(Survey $survey, QuestionAnswer $answer): bool
@@ -45,28 +36,16 @@ class ObjectHasFreeAreaEffectStrategy extends AbstractEffectStrategy
 	{
 		$chatMemberModel = $survey->chatMember->model;
 
-		$this->createTaskForMessage($surveyChatMemberMessage, $survey->user, $chatMemberModel);
+		$this->effectTaskService->createTaskForMessage(
+			$surveyChatMemberMessage,
+			$survey->user,
+			$surveyQuestionAnswer,
+			$this->getTaskMessage($chatMemberModel)
+		);
 	}
 
 	public function getTaskMessage(ObjectChatMember $objectChatMember): string
 	{
 		return sprintf(self::TASK_MESSAGE_TEXT, $objectChatMember->object_id);
-	}
-
-	/**
-	 * @throws ModelNotFoundException
-	 * @throws SaveModelException
-	 * @throws Throwable
-	 * @throws Exception
-	 */
-	protected function createTaskForMessage(ChatMemberMessage $message, User $user, ObjectChatMember $objectChatMember): void
-	{
-		$dto = $this->taskBuilderFactory
-			->createEffectBuilder()
-			->setMessage($this->getTaskMessage($objectChatMember))
-			->setCreatedBy($user)
-			->build();
-
-		$this->chatMemberMessageService->createTask($message, $dto);
 	}
 }

--- a/config/common/common/params.php
+++ b/config/common/common/params.php
@@ -9,7 +9,7 @@ $ftpOptionsForBackupsLoad = [
 	'password' => $secrets['ftp_options_for_backups_load']['password'], // required
 ];
 
-$common_thisHost = "http://crmka/";
+$common_thisHost = "http://crmka_nginx/";
 
 return [
 	'company_phone'  => '+7 (495) 150-03-23',

--- a/controllers/SurveyController.php
+++ b/controllers/SurveyController.php
@@ -72,8 +72,14 @@ class SurveyController extends AppController
 			        ->joinWith([
 				        'answers.surveyQuestionAnswer' => function (ActiveQuery $query) use ($id) {
 					        $query->where([SurveyQuestionAnswer::field('survey_id') => $id]);
+					        $query->with(['tasks.user.userProfile',
+					                      'tasks.tags',
+					                      'tasks.createdByUser.userProfile',
+					                      'tasks.observers.user.userProfile',
+					                      'tasks.targetUserObserver']);
 				        }
-			        ])->all(),
+			        ])
+			        ->all(),
 		);
 	}
 

--- a/dto/Task/CreateTaskDto.php
+++ b/dto/Task/CreateTaskDto.php
@@ -13,10 +13,11 @@ class CreateTaskDto extends BaseObject
 	public User               $user;
 	public string             $message;
 	public int                $status;
-	public ?DateTimeInterface $start = null;
-	public ?DateTimeInterface $end   = null;
+	public ?DateTimeInterface $start                  = null;
+	public ?DateTimeInterface $end                    = null;
 	public string             $created_by_type;
 	public int                $created_by_id;
 	public array              $tagIds;
 	public array              $observerIds;
+	public ?int               $surveyQuestionAnswerId = null;
 }

--- a/migrations/m250121_111831_add_morph_column_in_survey_question_answer_table.php
+++ b/migrations/m250121_111831_add_morph_column_in_survey_question_answer_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use app\kernel\console\Migration;
+
+/**
+ * Class m250121_111831_add_morph_column_in_survey_question_answer_table
+ */
+class m250121_111831_add_morph_column_in_survey_question_answer_table extends Migration
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public function safeUp()
+	{
+		$this->addMorphColumn('survey_question_answer');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function safeDown()
+	{
+		$this->dropMorphColumn('survey_question_answer');
+	}
+}

--- a/models/SurveyQuestionAnswer.php
+++ b/models/SurveyQuestionAnswer.php
@@ -7,9 +7,12 @@ use app\helpers\TypeConverterHelper;
 use app\kernel\common\models\AR\AR;
 use app\models\ActiveQuery\FieldQuery;
 use app\models\ActiveQuery\QuestionAnswerQuery;
+use app\models\ActiveQuery\RelationQuery;
 use app\models\ActiveQuery\SurveyQuery;
 use app\models\ActiveQuery\SurveyQuestionAnswerQuery;
+use app\models\ActiveQuery\TaskQuery;
 use Throwable;
+use yii\base\ErrorException;
 use yii\base\Exception;
 use yii\db\ActiveQuery;
 use yii\helpers\Json;
@@ -17,14 +20,16 @@ use yii\helpers\Json;
 /**
  * This is the model class for table "survey_question_answer".
  *
- * @property int            $id
- * @property int            $survey_id
- * @property int            $question_answer_id
- * @property string|null    $value
+ * @property int             $id
+ * @property int             $survey_id
+ * @property int             $question_answer_id
+ * @property string|null     $value
  *
- * @property QuestionAnswer $questionAnswer
- * @property Survey         $survey
- * @property-read Field     $field
+ * @property QuestionAnswer  $questionAnswer
+ * @property Survey          $survey
+ * @property-read Field      $field
+ * @property-read Task[]     $tasks
+ * @property-read Relation[] $relationSecond
  */
 class SurveyQuestionAnswer extends AR
 {
@@ -74,6 +79,25 @@ class SurveyQuestionAnswer extends AR
 	{
 		/** @var FieldQuery */
 		return $this->hasOne(Field::class, ['id' => 'field_id'])->via('questionAnswer');
+	}
+
+	/**
+	 * @throws ErrorException
+	 */
+	public function getRelationSecond(): RelationQuery
+	{
+		/** @var RelationQuery */
+		return $this->morphHasMany(Relation::class, 'id', 'second');
+	}
+
+	/**
+	 * @throws ErrorException
+	 */
+	public function getTasks(): TaskQuery
+	{
+		/** @var TaskQuery */
+		return $this->morphHasManyVia(Task::class, 'id', 'first')
+		            ->via('relationSecond');
 	}
 
 	protected function toBool(): bool

--- a/resources/Survey/SurveyQuestionAnswerResource.php
+++ b/resources/Survey/SurveyQuestionAnswerResource.php
@@ -6,6 +6,8 @@ namespace app\resources\Survey;
 
 use app\kernel\web\http\resources\JsonResource;
 use app\models\SurveyQuestionAnswer;
+use app\resources\Task\TaskResource;
+use yii\helpers\Json;
 
 class SurveyQuestionAnswerResource extends JsonResource
 {
@@ -22,7 +24,9 @@ class SurveyQuestionAnswerResource extends JsonResource
 			'id'                 => $this->resource->id,
 			'question_answer_id' => $this->resource->question_answer_id,
 			'survey_id'          => $this->resource->survey_id,
-			'value'              => json_decode($this->resource->value),
+			'value'              => Json::decode($this->resource->value),
+
+			'tasks' => TaskResource::collection($this->resource->tasks)
 		];
 	}
 }


### PR DESCRIPTION
1. К SurveyQuestionAnswer теперь можно крепить Task с помощью RelationService.
Это нужно, чтобы прикреплять задачи к опросникам рядом с нужным вопросом и корректно выводить это на фронтенде. Лучше связи, лучше UX для сотрудников.

2. EffectStrategy немного отрефакторены, вынесены действия в два сервиса (чтобы не дублировать код из эффекта в эффект). Один из сервисов создает задачи по эффекту, второй умеет создавать системные сообщения по эффекту.